### PR TITLE
Resolve Github action bot Permission denied Error

### DIFF
--- a/.github/workflows/create-branch.yml
+++ b/.github/workflows/create-branch.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.TOKEN }}
           fetch-depth: 0
 
       - name: Create and push branch


### PR DESCRIPTION
This PR addresses the permission issue in the 'Create Issue Branch' GitHub Actions workflow by adding a token to the `actions/checkout` action.